### PR TITLE
Fixed multibyte string encoding error. Fixed preference error

### DIFF
--- a/app/models/spree/suggestion.rb
+++ b/app/models/spree/suggestion.rb
@@ -2,7 +2,7 @@ class Spree::Suggestion < ActiveRecord::Base
   validates :keywords, :presence => true
 
   def self.relevant(term)
-    config = Spree::Suggestion::Config
+    config = Spree::Autosuggest::Config
 
     select(:keywords).
       where("count >= ?", config.min_count).

--- a/lib/key_switcher.rb
+++ b/lib/key_switcher.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 module KeySwitcher
   extend self
 

--- a/lib/spree_autosuggest/engine.rb
+++ b/lib/spree_autosuggest/engine.rb
@@ -1,11 +1,14 @@
+module Spree::Autosuggest
+end
+
 module SpreeAutosuggest
   class Engine < Rails::Engine
     engine_name 'spree_autosuggest'
 
     config.autoload_paths += %W(#{config.root}/lib)
 
-    initializer "spree.suggestion.preferences", :before => :load_config_initializers do |app|
-      Spree::Suggestion::Config = Spree::SuggestionConfiguration.new
+    initializer "spree.suggestion.preferences", :after => "spree.environment" do |app|
+      Spree::Autosuggest::Config = Spree::SuggestionConfiguration.new
     end
 
     # use rspec for tests


### PR DESCRIPTION
I was getting the following error accessing the ::Config object when running this plugin:
    undefined method `min_count' for RbConfig:Module

Was getting an error parsing the russian string identifier. Adding UTF8 encoding identifier to the top worked.
